### PR TITLE
Updated transfer docs

### DIFF
--- a/docs/astronomy/astronomy_software.md
+++ b/docs/astronomy/astronomy_software.md
@@ -35,10 +35,10 @@ srun /carta_share/hdf_convert/run_hdf_converter image.fits /carta_share/users/<u
 
 ## Transfer data from the SARAO archive
 
-If you are a project lead or project member of one of the astronomy LSPs or other astronomy projects whose project proposal has been accepted by SARAO and are currently using the ilifu research cloud platform you may need to transfer your observation data from the SARAO archives to the ilifu cluster.
+If you are a principal investigator (PI) or member of one of the MeerKAT projects whose proposal has been accepted by SARAO, such as a Large Survey Project (LSP) or an Open Time Project, you may want to transfer your observational data from the SARAO archive to the ilifu cluster.
 
-In order to do this, please go to https://archive.sarao.ac.za and register yourself on the SARAO archive. Once you have registered, send an email to archive@ska.ac.za requesting access to your proposal.
+Before pushing your data, it is important to have an existing project on the ilifu cluster in order for us to make the data available to the project members. If you do not have an existing ilifu project, please make contact with the ilifu support team at support@ilifu.ac.za to request one, and notify us of your intention to transfer data.
+
+In order to push your data from SARAO to ilifu, a PI, or a representative that a PI has nominated, must go to https://archive.sarao.ac.za and register an account. Once they have registered, the PI must send an email to archive@ska.ac.za requesting for this person to access the proposal.
 
 The user guide for the archive is available [here](https://archive.sarao.ac.za/statics/Archive_Interface_User_Guide.pdf).
-
-Before pushing your data, please make contact with the ilifu support team at support@ilifu.ac.za to notify us of your intention to transfer data. It is important to have an existing project on the ilifu cluster in order for us to make the data available to you and other project members.

--- a/docs/data/data_transfer.md
+++ b/docs/data/data_transfer.md
@@ -1,14 +1,14 @@
-# Data transfer to and from the Ilifu Cluster
+# Data transfer to and from the ilifu Cluster
 
-Transfering of data to and from the ilifu research cloud can be completed using `scp` or `rsync`. For large files the `Globus Online` (using gridftp) software is availabe. **Please do not transfer data to and from the ilifu cluster using the SLURM head node as this will significantly diminish the performance of the head node for other users**.
+Transferring of data to and from the ilifu research cloud can be completed using `Globus`, `scp` or `rsync`. For large files the `Globus Online` software is recommended, which uses efficient GridFTP transfer protocols. **Please do not transfer data to and from the ilifu cluster using the SLURM head node, as this will significantly diminish the performance of the head node for other users**.
 
-Transfering astronomy observation data from the SARAO archive is also detailed below.
+Transferring astronomy observation data from the SARAO archive is also detailed [below](#transfer-data-from-the-sarao-archive).
 
 ## Transfer using scp and rsync
 
-A dedicated transfer node is available at `transfer.ilifu.ac.za` for transfering files using `scp` and `rsync` to and from the ilifu cluster. All users may ssh onto this transfer node.
+A dedicated transfer node is available at `transfer.ilifu.ac.za` for transferring files using `scp` and `rsync` to and from the ilifu cluster. All users may ssh onto this transfer node.
 
-The `scp` and `rsync` tools are useful to transfer data up to 200 GB, or if you're not expecting to transfer data frequently. For files over 200 GB or for frequent transfer of large files it is recommended to use the Globus Online software below. **Please note that large files should not be copied into your `/users/` directory.**
+The `scp` and `rsync` tools are useful for transferring data up to 200 GB, or if you're not expecting to transfer data frequently. For files over 200 GB or for frequent transfers, it is recommended to use the Globus Online software below. **Please note that large files should not be copied into your `/users/` directory.**
 
 The following is an example of how to scp from your personal computer to the ilifu cluster. From the terminal on your personal computer:
 
@@ -28,7 +28,7 @@ For more information about the `scp` and `rysnc` tools please read the manual pa
 
 The `Globus Online` software is available at [https://app.globus.org](https://app.globus.org).
 
-There are a number of different options for signing in. It may be possible to login using your institution's credentials by searching for your institution's name. Other login options are also available, if you don’t want to link your Globus account to another account, then select `Use Globus ID to sign in` and you’ll be able to create an account specific to Globus.
+There are a number of different options for signing in. It may be possible to login using your institution's credentials by searching for your institution's name. Other login options are also available. If you don’t want to link your Globus account to another account, then select `Use Globus ID to sign in` and you’ll be able to create an account specific to Globus.
 
 <div style="text-align:center"><img src="http://docs.ilifu.ac.za/_media/data_globus_01.png" alt="globus online login" width=500 /></div>
 
@@ -50,15 +50,15 @@ You’ll then be redirected to a window where you’ll be able to browse through
 
 <div style="text-align:center"><img src="http://docs.ilifu.ac.za/_media/data_globus_05.png" alt="globus online options menu" width=200 /></div>
 
-Select `Transfer or Sync to...` to select the other endpoint in your file transfer. This will open up another panel where you’ll need to complete the login process on another node similar to how you logged into the ilifu DTN.
+Select `Transfer or Sync to...` to select the other endpoint in your file transfer. This will open up another panel for selecting the other endpoint, which you'll need to configure.
 
 <div style="text-align:center"><img src="http://docs.ilifu.ac.za/_media/data_globus_06.png" alt="globus online set endpoint" width=600 /></div>>
 
-You can also use Globus to transfer files between ilifu and your desktop using the `Globus Connect Personal`. This software can also be installed on computing clusters. However, for best support and reliability, if the destination you wish to transfer files operates an endpoint already registered with Globus it is highly recommended to use this endpoint instead. Just search for the endpoint in the collections box on the right as before and supply your credentials there.
+#### Setting Up An Endpoint for your Desktop
 
-If your institution does not already have a Globus endpoint, you can setup Globus Connect Personal on Linux. Click [here](https://docs.globus.org/how-to/globus-connect-personal-linux/#globus-connect-personal-cli) if you’re installing on a computing cluster or, if you’re installing on your personal computer, click [here](https://docs.globus.org/how-to/globus-connect-personal-linux/) for Linux, [here](https://docs.globus.org/how-to/globus-connect-personal-mac) for Mac OS X, or [here](https://docs.globus.org/how-to/globus-connect-personal-windows) for Windows.
+You can also use Globus to transfer files between ilifu and your desktop using the `Globus Connect Personal`. For installing on your personal computer, click [here](https://docs.globus.org/how-to/globus-connect-personal-linux/) for Linux, [here](https://docs.globus.org/how-to/globus-connect-personal-mac) for Mac OS X, or [here](https://docs.globus.org/how-to/globus-connect-personal-windows) for Windows.
 
-Note that by default you may be unable to access paths outside your home directory using Globus Connect Personal for Linux.  Instructions on how to change the accessible paths can be found [here](https://docs.globus.org/faq/globus-connect-endpoints/#how_do_i_configure_accessible_directories_on_globus_connect_personal_for_linux).
+Note that by default you may be unable to access paths outside your home directory using Globus Connect Personal for Linux.  Instructions on how to change the accessible paths can be found [here](https://docs.globus.org/faq/globus-connect-endpoints/#_how_do_i_configure_accessible_directories_on_globus_connect_personal_for_linux).
 
 Once `Globus Connect Personal` is installed, head back to the `File Browser`, and select the box allowing you to specify the other collection to install.  On the resulting page you should then be able to select the `Your Collections` tab where you should find your `Globus Connect Personal` endpoint.  Select it by clicking on its name, in this case `Test Endpoint`.
 
@@ -83,16 +83,22 @@ You should then see a similar message appear on the page as the following:
 
 Globus will then inform your by email of the status of your transfer once it’s either failed or completed or you can click `Activity` in the sidebar to monitor its progress.
 
-At this point, as long as the Globus platform can reach both ilifu and the location you’re transferring files to, no connectivity is required to other machines, i.e. assuming you’ve installed the Globus Connect Personal software on a compute server (rather than on your personal computer), you should not have to worry if your laptop loses network connectivity or is shut down as long as the `Globus Connect Personal` software continues to run on the server.
+**Note that by default Globus will only be able to act on your behalf for 24 hours from since you last submitted your ilifu username and password in the Globus interface to login to the DTN.  At times you may need to extend the lifetime of your credentials.**  To do so, click `Endpoints` in the sidebar, select `ilifu DTN`, and you should then see a button labelled `Extend Activation` on the right hand side of the screen.  You’ll then see a login screen for the `ilifu DTN` similar to before where you can login to extend the credentials available to Globus for a further time period.  (A lifetime other than 24 hours can be specified by clicking `Advanced` and entering a different lifetime in hours, though individual transfers may still be limited to 24 hours each).
 
-**Note that by default Globus will only be able to act on your behalf for 24 hours from since you last submitted your ilifu username and password in the Globus interface to login to the DTN.  At times you may need to extend the lifetime of your credentials.**  To do so, click `Endpoints` in the sidebar, select `ilifu DTN`, and you should then see a button labelled `Extend Activation` on the right hand side of the screen.  You’ll then see a login screen for the `ilifu DTN` similar to before which you can login to extend the credentials available to Globus for a further time period.  (A lifetime other than 24 hours can be specified by clicking `Advanced` and entering a different lifetime in hours, though individual transfers may still be limited to 24 hours each).
+#### Setting Up An Endpoint for Another Data Transfer Node
+
+`Globus Connect Personal` can also be installed on computing clusters. However, for best support and reliability, if the destination to which you wish to transfer files operates an endpoint already registered with Globus, it is highly recommended to use this endpoint instead. Just search for the endpoint in the collections box on the right as before and complete the login process similar to how you logged into the ilifu DTN.
+
+If your institution does not already have a Globus endpoint, you can setup Globus Connect Personal on Linux. Click [here](https://docs.globus.org/how-to/globus-connect-personal-linux/#globus-connect-personal-cli) for installing on a computing cluster.
+
+Once a transfer is initiated, as long as the Globus platform can reach both ilifu and the location you’re transferring files to, no connectivity is required to other machines (i.e. assuming you’ve installed the Globus Connect Personal software on a compute server, rather than on your personal computer, you should not have to worry if your laptop loses network connectivity or is shut down, as long as the `Globus Connect Personal` software continues to run on the server.
 
 ## Transfer data from the SARAO archive
 
-If you are a project lead or project member of one of the astronomy LSPs or other astronomy projects whose project proposal has been accepted by SARAO and are currently using the ilifu research cloud platform you may need to transfer your observation data from the SARAO archives to the ilifu cluster.
+If you are a principal investigator (PI) or member of one of the MeerKAT projects whose proposal has been accepted by SARAO, such as a Large Survey Project (LSP) or an Open Time Project, you may want to transfer your observational data from the SARAO archive to the ilifu cluster.
 
-In order to do this, please go to https://archive.sarao.ac.za and register yourself on the SARAO archive. Once you have registered, send an email to archive@ska.ac.za requesting access to your proposal.
+Before pushing your data, it is important to have an existing project on the ilifu cluster in order for us to make the data available to the project members. If you do not have an existing ilifu project, please make contact with the ilifu support team at support@ilifu.ac.za to request one, and notify us of your intention to transfer data.
+
+In order to push your data from SARAO to ilifu, a PI, or a representative that a PI has nominated, must go to https://archive.sarao.ac.za and register an account. Once they have registered, the PI must send an email to archive@ska.ac.za requesting for this person to access the proposal.
 
 The user guide for the archive is available [here](https://archive.sarao.ac.za/statics/Archive_Interface_User_Guide.pdf).
-
-Before pushing your data, please make contact with the ilifu support team at support@ilifu.ac.za to notify us of your intention to transfer data. It is important to have an existing project on the ilifu cluster in order for us to make the data available to you and other project members.


### PR DESCRIPTION
Made small tweaks to SARAO-ilifu transfer docs. Added subsections for Globus docs, with "Setting Up An Endpoint for your Desktop" first, and "Setting Up An Endpoint for Another Data Transfer Node" second, since the latter doesn't seem like a common use case. Made small tweaks to this section too.