### PR TITLE
Rewrite interactive session docs 

### DIFF
--- a/docs/getting_started/submit_job_slurm.md
+++ b/docs/getting_started/submit_job_slurm.md
@@ -1,12 +1,12 @@
-# Submitting a job on SLURM
+# Submitting a job on Slurm
 
-Two common ways to run jobs on SLURM include submitting jobs using a batch script, and running jobs interactively. Submitting jobs using a batch script allows for multiple jobs to be submitted in parallel, or for a series of jobs to be submitted, where one job may depend on the output of a previous job. Interactive jobs are useful for developing workflows or scripts, or working with software interactively. 
+Two common ways to run jobs on Slurm include submitting jobs using a batch script, and running jobs interactively. Submitting jobs using a batch script allows for multiple jobs to be submitted in parallel, or for a series of jobs to be submitted, where one job may depend on the output of a previous job. Interactive jobs are useful for developing workflows or scripts, or working with software interactively. 
 
-**Note: No software should be run on the SLURM login node.** The login node (slurm.ilifu.ac.za) should only be used to start and interact with Slurm jobs, or other low-resource tasks. For any other work, please start an interactive job as described below. 
+**Note: No software should be run on the Slurm login node.** The login node (slurm.ilifu.ac.za) should only be used to start and interact with Slurm jobs, or other low-resource tasks. For any other work, please start an interactive job as described below. 
 
 ## Submitting a Job using a Batch Script
 
-After `sshing` into `slurm.ilifu.ac.za`, you can submit a job to SLURM using a shell script. The script must describe the application/software you wish to run as well as the resources that you wish to allocate to the job.
+After `sshing` into `slurm.ilifu.ac.za`, you can submit a job to Slurm using a shell script. The script must describe the application/software you wish to run as well as the resources that you wish to allocate to the job.
 
 Let us assume that you are trying to run a python script, `myscript.py` with the following contents:
 
@@ -28,27 +28,27 @@ Create a shell script, `my_slurm_script.sh` with the following:
 #SBATCH --error=testjob-%j-stderr.log
 #SBATCH --time=00:05:00
 
-echo "Submitting SLURM job"
+echo "Submitting Slurm job"
 singularity exec /idia/software/containers/ASTRO-PY3.simg python myscript.py
 ```
 
-The parameters that follow `#SBATCH` indicate the requested resources and other job parameters such as the job name and logging information. The `%j` in the output log file names is a placeholder for the job number or `jobid`. Run the  `sbatch --help` command from the terminal to see additional parameters or see the [table of parameters below](/getting_started/submit_job_slurm?id=slurm-job-parameters).
+The parameters that follow `#SBATCH` indicate the requested resources and other job parameters such as the job name and logging information. The `%j` in the output log file names is a placeholder for the job number or `jobid`. Run the `sbatch --help` command from the terminal to see additional parameters or see the [table of parameters below](/getting_started/submit_job_slurm?id=slurm-job-parameters).
 
 In the shell script above, the application you wish to run during the job is described by `singularity exec /data/exp_soft/containers/ASTRO-PY3.simg python myscript.py`. Here `python` is being used to run `myscript.py` using the python executable within the container `ASTRO-PY3.simg`. This is a `singularity` container that is called with the `exec` command to execute the script.
 
-The next step is to run the shell script using the SLURM `sbatch` command:
+The next step is to run the shell script using the Slurm `sbatch` command:
 
 ```bash
 	$ sbatch my_slurm_script.sh
 ```
 
-This will submit the job to the SLURM queue. If the requested resources are available the job will be initiated. You can see the status of all jobs in the SLURM queue by using the command:
+This will submit the job to the Slurm queue. If the requested resources are available the job will be initiated. You can see the status of all jobs in the Slurm queue by using the command:
 
 ```bash
 	$ squeue
 ```
 
-To see the status of the jobs in the SLURM queue associated with your account use:
+To see the status of the jobs in the Slurm queue associated with your account use:
 
 ```bash
 	$ squeue -u <username>
@@ -56,11 +56,11 @@ To see the status of the jobs in the SLURM queue associated with your account us
 
 If any errors occur while running the job, you can view the logs in the `testjob-<jobid>-stderr.log`, and any text output can be found in `testjob-<jobid>-stdout.log`, as described by the shell script. This is useful for debugging any issues with your job.
 
-## Interactive SLURM Sessions
+## Interactive Slurm Sessions
 
-An interactive session allows you to connect to a computing node and work on that node directly. There are several ways to use an interactive session on Ilifu. If you need to do work that you would normally do on a dedicated node, without waiting in the queue, the simplest option is to use the `sinteractive` command.  To use `sinteractive`, please see the Interactive Session Quick Start section below. 
+An interactive session allows you to connect to a computing node and work on that node directly. There are several ways to use an interactive session on Ilifu. If you need to do work that you would normally do on a dedicated node, without waiting in the queue, the simplest option is to use the `sinteractive` command. To use `sinteractive`, please see the Interactive Session Quick Start section below. 
 
-For more sophisticated interactive usage, the `srun` command accomodates a variety of modes and options. See the Interactive Session Features section below for  common features of the `srun` command.
+For more sophisticated interactive usage, the `srun` command accommodates a variety of modes and options. See the Interactive Session Features section below for common features of the `srun` command.
 
 Please note the following before starting an interactive job:
 
@@ -68,7 +68,7 @@ Please note the following before starting an interactive job:
 
 **Note:** In order is to ensure that resources are available in an optimal way for all users, interactive jobs are limited by time and compute resources. For work that uses significant compute resources, or that takes longer than three hours, we recommend that users submit jobs to the batch queue using `sbatch`. 
 
-**Note:** No software should be run on the SLURM login node (slurm.ilifu.ac.za). It should only be used to start, stop and monitor slurm jobs. 
+**Note:** No software should be run on the Slurm login node (slurm.ilifu.ac.za). The Slurm login node should only be used to start, stop and monitor Slurm jobs. 
 
 
 ### Interactive Session Quick Start
@@ -83,14 +83,14 @@ For example, run the following command on the login node to start an interactive
 
 After entering this command, you will be presented with a new prompt on a compute node where you can work directly.
 
-Most options that can be used with `sbatch` or `srun` can also be passed to the `sinteractive` command. We recommend specifying the flags for the number of cpus (`-c` or `--cpus-per-core`) and for job time (`--time=`). The default time limit for the Devel partition is three hours. The job will only remain active until the terminal is exited. Therefore, it is recommended to use `sinteractive` together with a persistent connection tool such as `tmux` or `GNU screen`. See the Persistent Terminals section below for instructions.
+Most options that can be used with `sbatch` or `srun` can also be passed to the `sinteractive` command. We recommend specifying the flags for the number of CPUs (`-c` or `--cpus-per-core`) and for job time (`--time=`). The default time limit for the Devel partition is three hours. The job will only remain active until the terminal is exited. Therefore, it is recommended to use `sinteractive` together with a persistent connection tool such as `tmux` or `GNU screen`. See the Persistent Terminals section below for instructions.
 
-In order to minimize wait time for interactive sessions, resources on the `Devel` partition are shared between all users -- memory is not tracked by slurm and the cpus are oversubscribed. Also, job time is limited to a maximum of twelve hours. Please only request the number of cores and time that you need for the task at hand and be aware of your memory usage. If you need an interactive job with additional features and options, with a dedicated allocation of compute resources, or that lasts longer than twelve hours, please use `srun` command, which is documented in the following section. 
+In order to minimize wait time for interactive sessions, resources on the `Devel` partition are shared between all users -- memory is not tracked by Slurm and the CPUs are oversubscribed. Also, job time is limited to a maximum of twelve hours. Please only request the number of cores and time that you need for the task at hand and be aware of your memory usage. If you need an interactive job with additional features and options, with a dedicated allocation of compute resources, or that lasts longer than twelve hours, please use `srun` command, which is documented in the following section. 
 
 
 ### Interactive Session Features
 
-If you need an interative session with more time, resouces or options, the `srun` command can be used. From the SLURM login node, run the command:
+If you need an interative session with more time, resources or options, the `srun` command can be used. From the Slurm login node, run the command:
 
 ```bash
 	$ srun --pty bash
@@ -120,7 +120,7 @@ Alternatively, the following command will open an interactive CASA session on a 
 	$ srun --pty singularity exec /idia/software/containers/casa-stable.img casa --log2term --nologger
 ```
 
-Incidently, you can submit non-interactive jobs to SLURM using the `srun` command without the `--pty` parameter, for example:
+Incidently, you can submit non-interactive jobs to Slurm using the `srun` command without the `--pty` parameter, for example:
 
 ```bash
 	$ srun singularity exec /idia/software/containers/ASTRO-PY3.simg python myscript.py
@@ -134,7 +134,7 @@ This will run the Python script `myscript.py` using the ASTRO-PY3 container on a
 
 ### Persistent Terminals
 
-As with any ssh connection, when using an interactive shell via the `srun` or `sinteractive` command, your session is vulnerable to being killed if you lose network connectivity. To avoid this, you can use a persistent terminal tool such as GNU's `screen` or `tmux` for an interactive session that can be reaccessed after the loss of the ssh session. In order to use this feature, `tmux` should be run from the login node before running `srun`. However, when using `tmux`, please make sure to exit the `tmux` session once your interactive session is complete in order to release the resources back to the SLURM pool. Basic `tmux` commands include:
+As with any ssh connection, when using an interactive shell via the `srun` or `sinteractive` command, your session is vulnerable to being killed if you lose network connectivity. To avoid this, you can use a persistent terminal tool such as GNU's `screen` or `tmux` for an interactive session that can be reaccessed after the loss of the ssh session. In order to use this feature, `tmux` should be run from the login node before running `srun`. However, when using `tmux`, please make sure to exit the `tmux` session once your interactive session is complete in order to release the resources back to the Slurm pool. Basic `tmux` commands include:
 
 | Syntax/keyboard shortcut               | Action                                    |
 |----------------------------------------|-------------------------------------------|
@@ -145,23 +145,23 @@ As with any ssh connection, when using an interactive shell via the `srun` or `s
 | ctrl/cmd-b + [                         | scroll current terminal                   |
 
 An example work flow for an interactive session can be described as follows:
-* login in to slurm login node
+* login in to Slurm login node
 * run tmux (or screen)
 * use the srun or sinteractive command to allocate yourself a compute node, describing your required resources
 * open a Singularity container and run your software.
 
-Note: In the rare occasion that the SLURM login node is restarted, even persistent terminal sessions will be lost.
+Note: In the rare occasion that the Slurm login node is restarted, even persistent terminal sessions will be lost.
 
 
 ### Interactive Session with X11 Support
 
-In the event that you wish to use software that provides a GUI, such as `CASA plotms`, you can start an interactive session with `X11 forwarding`. You must `ssh` into the SLURM login node with the `-Y` parameter, which sets your DISPLAY variable for trusted `X11 forwarding`, for example:
+In the event that you wish to use software that provides a GUI, such as `CASA plotms`, you can start an interactive session with `X11 forwarding`. You must `ssh` into the Slurm login node with the `-Y` parameter, which sets your DISPLAY variable for trusted `X11 forwarding`, for example:
 
 ```bash
 	$ ssh -Y <username>@slurm.ilifu.ac.za
 ```
 
-From there, you must use `--x11` to allocate a SLURM worker node to yourself with `X11 forwarding` as follows:
+From there, you must use `--x11` to allocate a Slurm compute node to yourself with `X11 forwarding` as follows:
 
 ```bash
 	$ sinteractive --x11
@@ -208,15 +208,15 @@ or for Mac OS:
 	$ ssh-add -K
 ``` -->
 
-## Specifying Resources when Running Jobs on SLURM
+## Specifying Resources when Running Jobs on Slurm
 
 When running a job using an `sbatch` script or using `srun` for an interactive job, a user is able to specify the resources required for their job. A single node consists of `32 CPUs` and `232 GB RAM`. These are the maximum number of resources that can be requested per node.
 
-If you are running a normal job on SLURM, **without** `MPI` or `OpenMP`, your job will only require `1 CPU`, `1 task` and `1 node`. These values are default values when running a job, however you are able to specify additional memory for your job using the `--mem` parameter.
+If you are running a normal job on Slurm, **without** `MPI` or `OpenMP`, your job will only require `1 CPU`, `1 task` and `1 node`. These values are default values when running a job, however you are able to specify additional memory for your job using the `--mem` parameter.
 
-Parallelism on the cluster can be achieved on a single node or over multiple nodes. Parallelism on a single node distributes work over multiple CPUs and is typically implemented using `OpenMP`. If you are running a job with software that utilizes `OpenMP` on SLURM, you can increase the number of CPUs for your job to > 1 CPU, while still using `1 task` and `1 node`. You may need to `export OMP_NUM_THREADS=<N>` to specify the number of threads the software will utilize.
+Parallelism on the cluster can be achieved on a single node or over multiple nodes. Parallelism on a single node distributes work over multiple CPUs and is typically implemented using `OpenMP`. If you are running a job with software that utilizes `OpenMP` on Slurm, you can increase the number of CPUs for your job to > 1 CPU, while still using `1 task` and `1 node`. You may need to `export OMP_NUM_THREADS=<N>` to specify the number of threads the software will utilize.
 
-Parallelism on the cluster can also occur by distributing work over many tasks that operate on 1 or more nodes. This type of parallelism is typically implemented using `MPI`. If you are running a job with software that utilizes `MPI` on SLURM, you can increase the number of `tasks` your job uses, `> 1 task`, while `nodes` and `CPUs` can be 1. The number of CPUs per task can be specified. You can increase the number of nodes if you want more than `32 CPUs` or `232 GB RAM`.
+Parallelism on the cluster can also occur by distributing work over many tasks that operate on 1 or more nodes. This type of parallelism is typically implemented using `MPI`. If you are running a job with software that utilizes `MPI` on Slurm, you can increase the number of `tasks` your job uses, `> 1 task`, while `nodes` and `CPUs` can be 1. The number of CPUs per task can be specified. You can increase the number of nodes if you want more than `32 CPUs` or `232 GB RAM`.
 
 The following table lists the parameters that can be used to describe the required resources for your job:
 
@@ -233,8 +233,8 @@ The following table lists the parameters that can be used to describe the requir
 
 **Note** default units for memory is MB, but can be specified explicitly in GB, example `--mem=16GB`.
 
-* a nodes refer to a single compute node or SLURM worker, i.e. one node has 32 CPUs and 232 GB RAM
-* a task is an instance of a running program, generally you will only want one task, unless you use software with MPI support (for example CASA), SLURM works with MPI to manage parallelised processing of data.
+* a nodes refer to a single compute node or Slurm worker, i.e. one node has 32 CPUs and 232 GB RAM
+* a task is an instance of a running program, generally you will only want one task, unless you use software with MPI support (for example CASA), Slurm works with MPI to manage parallelised processing of data.
 * CPUs refers to the the number of CPUs associated with your job.
 * default parameters, if not specified, include: 1 node; 1 task; 1 CPU and ~7 GB RAM (7424 MB or 7.25 GB); running on the Main partition for 3 hrs.
 * for more information, see [advanced usage](tech_docs/running_jobs#_4-specifying-resources-when-running-jobs-on-slurm)

--- a/docs/getting_started/submit_job_slurm.md
+++ b/docs/getting_started/submit_job_slurm.md
@@ -1,6 +1,8 @@
 # Submitting a job on SLURM
 
-Two common ways to run jobs on SLURM include submitting jobs using a batch script, and running jobs interactively. Submitting jobs using a batch script allows for multiple jobs to be submitted in parallel, or for a series of jobs to be submitted, where one job may depend on the output of a previous job. Interactive jobs are useful for developing workflows or scripts, or working with software interactively. **Please note that no software should be run on the SLURM login node (login node).**
+Two common ways to run jobs on SLURM include submitting jobs using a batch script, and running jobs interactively. Submitting jobs using a batch script allows for multiple jobs to be submitted in parallel, or for a series of jobs to be submitted, where one job may depend on the output of a previous job. Interactive jobs are useful for developing workflows or scripts, or working with software interactively. 
+
+**Note: No software should be run on the SLURM login node.** The login node (slurm.ilifu.ac.za) should only be used to start and interact with Slurm jobs, or other low-resource tasks. For any other work, please start an interactive job as described below. 
 
 ## Submitting a Job using a Batch Script
 
@@ -56,52 +58,69 @@ If any errors occur while running the job, you can view the logs in the `testjob
 
 ## Interactive SLURM Sessions
 
-**No software should be run on the SLURM login node.** A shell terminal can be run on a compute node allowing for an interactive job on the cluster. Interactive jobs are useful for testing and developing code.
+An interactive session allows you to connect to a computing node and work on that node directly. There are several ways to use an interactive session on Ilifu. If you need to do work that you would normally do on a dedicated node, without waiting in the queue, the simplest option is to use the `sinteractive` command.  To use `sinteractive`, please see the Interactive Session Quick Start section below. 
 
-**NOTE:** interactive sessions are volatile and may be lost if you lose connection to the ilifu cluster. Persistent terminals, such as `tmux` or `screen` may help to reduce this volatility, however, in the event that the SLURM login node is restarted, the persistent terminal sessions will be lost. We therefore recommend that users submit jobs using `sbatch`, particularly for jobs with run times of greater than 3 hrs.
+For more sophisticated interactive usage, the `srun` command accomodates a variety of modes and options. See the Interactive Session Features section below for  common features of the `srun` command.
 
-**NOTE:** interactive sessions make use of the same resource pool as jobs submitted using `sbatch`. If you are experiencing delays acquiring an interactive session you can either try to reduce the number of resources (CPU, memory and run-time) that you are requesting, or use the parameter `--qos qos-interactive` when launching your interactive job. This parameter provides increased priority but is limited to 1 job, 4 CPUs and 28 GB memory.
+Please note the following before starting an interactive job:
 
-### Quick Interactive Session
+**Note:** Interactive sessions may be lost if you lose connection to the ilifu cluster. Persistent terminals, such as `tmux` or GNU `screen` can help to reduce volatility. See the section Persistent Terminals for instructions. 
 
-If you need to do interactive work and don't want to wait in the queue, the `sinteractive` command provides on-demand access to an allocation of resources in the `Devel` partition. It is designed to elimiate wait time by sharing resources between mulitple users. The `sinteractive` command can often be used in cases where a dedicated server would otherwise be used. That is, when testing scripts, developing code, compiling, or for other tasks that are difficult to accomplish with a batch queue system and which cannot be done on the login node.
+**Note:** In order is to ensure that resources are available in an optimal way for all users, interactive jobs are limited by time and compute resources. For work that uses significant compute resources, or that takes longer than three hours, we recommend that users submit jobs to the batch queue using `sbatch`. 
 
-The following command will launch a job in the `Devel` partition with four cores, X11 support, and will automatically open an virtual terminal on the appropriate node:
+**Note:** No software should be run on the SLURM login node (slurm.ilifu.ac.za). It should only be used to start, stop and monitor slurm jobs. 
+
+
+### Interactive Session Quick Start
+
+If you need to do interactive work and don't want to wait in the queue, the `sinteractive` command aims to provide on-demand access to resources on the `Devel` partition. This partition is designed to elimiate wait time by sharing resources between mulitple users. The `sinteractive` is a wrapper around the `srun` command that allows you to quickly start a job on the `Devel` partition, connect to the appropriate server, and work on that server directly with minimal configuration. 
+
+For example, run the following command on the login node to start an interactive session with four cores and X11 support:
 
 ```bash
 	$ sinteractive --x11 -c 4
 ```
 
-Most options that can be used with `sbatch` or `srun` can also be passed to the `sinteractive` command. We recommend specifying the flags for cpu (`-c` or `--cpus-per-core`) and for time (`--time=`), if you need more than the default time limit of three hours. The job will only remain active until the terminal is exited. Therefore, it is recommended to use `sinteractive` together with a tool such as `tmux` or `GNU screen` in order to maintain a persistent connection. See the instructions for `tmux` in the following section.
+After entering this command, you will be presented with a new prompt on a compute node where you can work directly.
 
-In order to provide immediate access for interactive tasks, resources are shared between all users on the `Devel` partition -- memory is not tracked and the cpus are oversubscribed. Please only request the number of cores that you need for the task at hand and be aware of your memory usage. 
+Most options that can be used with `sbatch` or `srun` can also be passed to the `sinteractive` command. We recommend specifying the flags for the number of cpus (`-c` or `--cpus-per-core`) and for job time (`--time=`). The default time limit for the Devel partition is three hours. The job will only remain active until the terminal is exited. Therefore, it is recommended to use `sinteractive` together with a persistent connection tool such as `tmux` or `GNU screen`. See the Persistent Terminals section below for instructions.
 
-For more features of interactive jobs, refer to the following sections. 
+In order to minimize wait time for interactive sessions, resources on the `Devel` partition are shared between all users -- memory is not tracked by slurm and the cpus are oversubscribed. Also, job time is limited to a maximum of twelve hours. Please only request the number of cores and time that you need for the task at hand and be aware of your memory usage. If you need an interactive job with additional features and options, with a dedicated allocation of compute resources, or that lasts longer than twelve hours, please use `srun` command, which is documented in the following section. 
 
 
-### Interactive Session without X11 Support
+### Interactive Session Features
 
-For an interative session on the SLURM cluster the `srun` command can be used as follows, from the SLURM login node:
+If you need an interative session with more time, resouces or options, the `srun` command can be used. From the SLURM login node, run the command:
 
 ```bash
 	$ srun --pty bash
 ```
 
-This will place you in an interactive shell (bash) session on a compute node. The `--pty` parameter provides a psuedo-terminal which allows interactivity. The default resources allocated by the `srun` command are 1 task, 1 CPU and ~7 GB RAM. Run the `srun --help` command to see additional parameters. Similar parameters to the sbatch script above can be used to define the resources allocated to your interactive session. From the shell session, you are able to run interactive tasks, such as opening a Singularity container and loading an interactive CASA session, or utilizing Nextflow.
+This will place you in an interactive (bash) shell on a compute node in the Main partition. The `--pty` parameter provides a psuedo-terminal that allows for interactivity. The default resources allocated by the `srun` command are 1 task, 1 CPU and ~7 GB RAM. Run the `srun --help` command to see additional parameters. Similar parameters to the sbatch command can be used to define the resources and other options of your interactive session. From the shell session, you are able to run interactive tasks, such as opening a Singularity container to load an interactive CASA session, or to utilizing Nextflow.
 
-You are able to directly run Singularity containers or software within containers using the srun command, for example:
+To start an interactive session without waiting in the queue, the `Devel` partition can be used for an on-demand session on a resource-shared node.
+
+```bash
+	$ srun -p Devel --pty bash -i
+```
+
+Note that, as memory is not tracked in the `Devel` partition, specifying any memory argument (e.g. the -m or --mem flags) with the `Devel` partition will yeild an error stating that "Memory required by task is not available".
+
+You can directly run a Singularity containers or other software using the srun command, for example:
 
 ```bash
 	$ srun --pty singularity shell /idia/software/containers/ASTRO-PY3.simg
 ```
 
-This will open an interactive session on a compute node and open the `ASTRO-PY3` container which includes a large suite of astronomy software. Alternatively, the following command will open an interactive CASA session on a compute node using the casa-stable.img container:
+This will start an interactive session on a compute node and open a shell in the `ASTRO-PY3` container, which contains a large suite of astronomy software. 
+
+Alternatively, the following command will open an interactive CASA session on a compute node using the casa-stable.img container:
 
 ```bash
 	$ srun --pty singularity exec /idia/software/containers/casa-stable.img casa --log2term --nologger
 ```
 
-Incidently, you can also submit non-interactive jobs to SLURM using the `srun` command without the `--pty` parameter, for example:
+Incidently, you can submit non-interactive jobs to SLURM using the `srun` command without the `--pty` parameter, for example:
 
 ```bash
 	$ srun singularity exec /idia/software/containers/ASTRO-PY3.simg python myscript.py
@@ -109,7 +128,13 @@ Incidently, you can also submit non-interactive jobs to SLURM using the `srun` c
 
 This will run the Python script `myscript.py` using the ASTRO-PY3 container on a compute node, similar to the `sbatch` command, however the job will not be run in the background, but will utilize your current terminal.
 
-Note that when using an interactive shell on SLURM by using the `srun` command, your interactive session may be vulnerable to being killed if you lose network connectivity. To avoid this, you can use `tmux` for a persistent terminal that can be reaccessed after the loss of the ssh session. In order to use this feature, `tmux` should be run from the login node before running `srun`. However, when using `tmux`, please make sure to exit the `tmux` session once your interactive session is complete in order to release the resources back to the SLURM pool. Basic `tmux` commands include:
+**Note:** Interactive sessions using `srun` make use of the same resource pool as jobs submitted using `sbatch`. If you are experiencing delays acquiring an interactive session you can either try to reduce the number of resources (CPU, memory and run-time) that you are requesting, or use the parameter `--qos qos-interactive` when launching your interactive job. This parameter provides increased priority but is limited to 1 job, 4 CPUs and 28 GB memory. Alternatively, you can use the `Devel` partition (`srun -p Devel`) or the `sinteractive` command for on-demand access to a shared node.
+
+
+
+### Persistent Terminals
+
+As with any ssh connection, when using an interactive shell via the `srun` or `sinteractive` command, your session is vulnerable to being killed if you lose network connectivity. To avoid this, you can use a persistent terminal tool such as GNU's `screen` or `tmux` for an interactive session that can be reaccessed after the loss of the ssh session. In order to use this feature, `tmux` should be run from the login node before running `srun`. However, when using `tmux`, please make sure to exit the `tmux` session once your interactive session is complete in order to release the resources back to the SLURM pool. Basic `tmux` commands include:
 
 | Syntax/keyboard shortcut               | Action                                    |
 |----------------------------------------|-------------------------------------------|
@@ -122,12 +147,15 @@ Note that when using an interactive shell on SLURM by using the `srun` command, 
 An example work flow for an interactive session can be described as follows:
 * login in to slurm login node
 * run tmux (or screen)
-* use the srun command to allocate yourself a compute node, describing your required resources
+* use the srun or sinteractive command to allocate yourself a compute node, describing your required resources
 * open a Singularity container and run your software.
+
+Note: In the rare occasion that the SLURM login node is restarted, even persistent terminal sessions will be lost.
+
 
 ### Interactive Session with X11 Support
 
-In the event that you wish to use software which provides a GUI, such as `CASA plotms`, you can start an interactive session with `X11 forwarding`. You must `ssh` into the SLURM login node with the `-Y` parameter which sets your DISPLAY variable for trusted `X11 forwarding`, for example:
+In the event that you wish to use software that provides a GUI, such as `CASA plotms`, you can start an interactive session with `X11 forwarding`. You must `ssh` into the SLURM login node with the `-Y` parameter, which sets your DISPLAY variable for trusted `X11 forwarding`, for example:
 
 ```bash
 	$ ssh -Y <username>@slurm.ilifu.ac.za
@@ -136,13 +164,19 @@ In the event that you wish to use software which provides a GUI, such as `CASA p
 From there, you must use `--x11` to allocate a SLURM worker node to yourself with `X11 forwarding` as follows:
 
 ```bash
+	$ sinteractive --x11
+```
+
+or,
+
+```bash
 	$ srun --x11 --pty bash
 ```
 
 This will place you in an interactive shell (bash) session on a compute node with `X11 forwarding` enabled. The default resources allocated by the `srun` command are 1 task, 1 CPU and ~7 GB RAM. You can again adjust what resources are allocated to your interactive session using the parameters such as `--cpus-per-task`, or `--mem`, for example:
 
 ```bash
-	$ srun --pty --cpus-per-task=2 --mem=16GB --x11 bash
+	$ srun --cpus-per-task=2 --mem=16GB --x11 --pty bash
 ```
 
 You are then able to run a Singularity container and run software that provides a GUI.

--- a/docs/tech_docs/running_jobs.md
+++ b/docs/tech_docs/running_jobs.md
@@ -2,15 +2,15 @@
 
 The Ilifu facility has two main services for accessing compute resources:
 
-1. **Jupyter** Users may access a JupyterLab session on the cluster. The Ilifu Jupyter service allows users to select their desired compute resouces and dynamically spawn a Jupyter session. This is a good environment to experiment with code and visualise results. This jupyter service is available at [jupyter.ilifu.ac.za](https://jupyter.ilifu.ac.za)
+1. **Jupyter** Users may access a JupyterLab session on the cluster. The Ilifu Jupyter service allows users to select their desired compute resources and dynamically spawn a Jupyter session. This is a good environment to experiment with code and visualise results. This Jupyter service is available at [jupyter.ilifu.ac.za](https://jupyter.ilifu.ac.za)
 
-2. Users may access the Ilifu SLURM cluster login-node and submit tasks to the SLURM queue. This environment is available at [slurm.ilifu.ac.za](https://slurm.ilifu.ac.za).
+2. Users may access the Ilifu Slurm cluster login-node and submit tasks to the Slurm queue. This environment is available at [slurm.ilifu.ac.za](https://slurm.ilifu.ac.za).
 
 ---
 
 ## Jupyter Spawner
 
-The Jupyter spawner can be accessed via web browser at `https://jupyter.ilifu.ac.za`.  This system allows the user to spawn a virtual machine on the Ilifu cloud running Jupyter Lab. Since the VM is launched for each user it allows for better management of resources, and provides a reliable environment for developing and running analyses, since users are not competing for resources on one or more shared nodes.
+The Jupyter spawner can be accessed via web browser at `https://jupyter.ilifu.ac.za`. This system allows the user to spawn a virtual machine on the Ilifu cloud running Jupyter Lab. Since the VM is launched for each user it allows for better management of resources, and provides a reliable environment for developing and running analyses, since users are not competing for resources on one or more shared nodes.
 
 After logging into the Jupyter node, the user is presented with a drop-down menu with a list of options for compute resources. Please select the smallest node that will provide sufficient resources for the task at hand:
 ![dropdown](http://docs.ilifu.ac.za/_media/profile_dropdown_options.png)
@@ -56,17 +56,17 @@ Details of the python libraries, software and other libraries available within t
 
 ## Slurm Batch Scheduler
 
-Slurm is a general purpose job scheduling system which is highly versatile. There are numerous resources available online as to how to submit batch jobs and how to control the execution, concurrency, and dependencies of jobs. This page provides instructions for connecting to the batch scheduler and a simple example to submit and run a SLURM batch job.
+Slurm is a general purpose job scheduling system which is highly versatile. There are numerous resources available online as to how to submit batch jobs and how to control the execution, concurrency, and dependencies of jobs. This page provides instructions for connecting to the batch scheduler and a simple example to submit and run a Slurm batch job.
 
-The SLURM batch system can be accessed via `ssh` with private key to `slurm.ilifu.ac.za`. Note that this node should only be used to submit and manage batch jobs and not for running code or software directly. The login node does not have significant resources and will likely crash under heavy usage. From this node you can submit jobs to a queue where it is subsequently allocated to the computing cluster such that it uses resources in an optimal manner.
+The Slurm batch system can be accessed via `ssh` with private key to `slurm.ilifu.ac.za`. Note that this node should only be used to submit and manage batch jobs and not for running code or software directly. The login node does not have significant resources and will likely crash under heavy usage. From this node you can submit jobs to a queue where it is subsequently allocated to the computing cluster such that it uses resources in an optimal manner.
 
-To do so, we must create a job submit script. In this example, we will assume that the user is executing their analysis or data processing code using python. We  also assume that your code is contained in a set of python script called `casa_job_N.py`, where N represents the job number. If you were working directly on your laptop, you could run this script by running `python -c casa_job_N.py`. However, since our script will be run on a worker node, we need to use a singularity container to encapsulate our system environment and requisite software. To execute our python script on the Ilifu cluster using a singularity container, we prepend `singularity exec` to this command:
+To do so, we must create a job submit script. In this example, we will assume that the user is executing their analysis or data processing code using python. We also assume that your code is contained in a set of python script called `casa_job_N.py`, where N represents the job number. If you were working directly on your laptop, you could run this script by running `python -c casa_job_N.py`. However, since our script will be run on a worker node, we need to use a singularity container to encapsulate our system environment and requisite software. To execute our python script on the Ilifu cluster using a singularity container, we prepend `singularity exec` to this command:
 
 ```bash
 singularity exec /data/exp_soft/containers/casa-stable.img python -c casa_job_N.py
 ```
 
-To execute our (set of) scripts using the SLURM batch scheduler, you must create an additional SLURM submit script. This is a bash script that contains the above command, along with a set of parameters that instruct SLURM how to run the jobs:
+To execute our (set of) scripts using the Slurm batch scheduler, you must create an additional Slurm submit script. This is a bash script that contains the above command, along with a set of parameters that instruct Slurm how to run the jobs:
 
 ```bash
 #!/bin/bash
@@ -76,12 +76,12 @@ To execute our (set of) scripts using the SLURM batch scheduler, you must create
 #SBATCH --time=00:20:00
 #SBATCH --output=logs/casalog_%J.log
 
-echo "Submitting SLURM job"
+echo "Submitting Slurm job"
 singularity exec /data/exp_soft/containers/casa-stable.img casa -c casa_job_N.py
 sleep 10
 ```
 
-The commented lines beginning with _#SBATCH_ are parsed by the SLURM to determine how to run the jobs.  The above script creates a log file for each job, these scripts are located in the 'logs' directory, so make sure that such a directory exists relative to the location where you submit the script.
+The commented lines beginning with _#SBATCH_ are parsed by the Slurm to determine how to run the jobs. The above script creates a log file for each job, these scripts are located in the 'logs' directory, so make sure that such a directory exists relative to the location where you submit the script.
 
 To submit this script to the job queue, run
 
@@ -93,11 +93,11 @@ To check the progress of the jobs, use the `squeue` command or check the `logs` 
 
 
 
-## Interactive SLURM Sessions
+## Interactive Slurm Sessions
 
-An interactive session allows you to connect to a computing node and work on that node directly. There are several ways to use an interactive session on Ilifu. If you need to do work that you would normally do on a dedicated node, without waiting in the queue, the simplest option is to use the `sinteractive` command.  To use `sinteractive`, please see the Interactive Session Quick Start section below. 
+An interactive session allows you to connect to a computing node and work on that node directly. There are several ways to use an interactive session on Ilifu. If you need to do work that you would normally do on a dedicated node, without waiting in the queue, the simplest option is to use the `sinteractive` command. To use `sinteractive`, please see the Interactive Session Quick Start section below. 
 
-For more sophisticated interactive usage, the `srun` command accomodates a variety of modes and options. See the Interactive Session Features section below for  common features of the `srun` command.
+For more sophisticated interactive usage, the `srun` command accommodates a variety of modes and options. See the Interactive Session Features section below for common features of the `srun` command.
 
 Please note the following before starting an interactive job:
 
@@ -105,7 +105,7 @@ Please note the following before starting an interactive job:
 
 **Note:** In order is to ensure that resources are available in an optimal way for all users, interactive jobs are limited by time and compute resources. For work that uses significant compute resources, or that takes longer than three hours, we recommend that users submit jobs to the batch queue using `sbatch`. 
 
-**Note:** No software should be run on the SLURM login node (slurm.ilifu.ac.za). It should only be used to start, stop and monitor slurm jobs. 
+**Note:** No software should be run on the Slurm login node (slurm.ilifu.ac.za). It should only be used to start, stop and monitor Slurm jobs. 
 
 
 ### Interactive Session Quick Start
@@ -120,14 +120,14 @@ For example, run the following command on the login node to start an interactive
 
 After entering this command, you will be presented with a new prompt on a compute node where you can work directly.
 
-Most options that can be used with `sbatch` or `srun` can also be passed to the `sinteractive` command. We recommend specifying the flags for the number of cpus (`-c` or `--cpus-per-core`) and for job time (`--time=`). The default time limit for the Devel partition is three hours. The job will only remain active until the terminal is exited. Therefore, it is recommended to use `sinteractive` together with a persistent connection tool such as `tmux` or `GNU screen`. See the Persistent Terminals section below for instructions.
+Most options that can be used with `sbatch` or `srun` can also be passed to the `sinteractive` command. We recommend specifying the flags for the number of CPUs (`-c` or `--cpus-per-core`) and for job time (`--time=`). The default time limit for the Devel partition is three hours. The job will only remain active until the terminal is exited. Therefore, it is recommended to use `sinteractive` together with a persistent connection tool such as `tmux` or `GNU screen`. See the Persistent Terminals section below for instructions.
 
-In order to minimize wait time for interactive sessions, resources on the `Devel` partition are shared between all users -- memory is not tracked by slurm and the cpus are oversubscribed. Also, job time is limited to a maximum of twelve hours. Please only request the number of cores and time that you need for the task at hand and be aware of your memory usage. If you need an interactive job with additional features and options, with a dedicated allocation of compute resources, or that lasts longer than twelve hours, please use `srun` command, which is documented in the following section. 
+In order to minimize wait time for interactive sessions, resources on the `Devel` partition are shared between all users -- memory is not tracked by Slurm and the cpus are oversubscribed. Also, job time is limited to a maximum of twelve hours. Please only request the number of cores and time that you need for the task at hand and be aware of your memory usage. If you need an interactive job with additional features and options, with a dedicated allocation of compute resources, or that lasts longer than twelve hours, please use `srun` command, which is documented in the following section. 
 
 
 ### Interactive Session Features
 
-If you need an interative session with more time, resouces or options, the `srun` command can be used. From the SLURM login node, run the command:
+If you need an interative session with more time, resouces or options, the `srun` command can be used. From the Slurm login node, run the command:
 
 ```bash
 	$ srun --pty bash
@@ -157,7 +157,7 @@ Alternatively, the following command will open an interactive CASA session on a 
 	$ srun --pty singularity exec /idia/software/containers/casa-stable.img casa --log2term --nologger
 ```
 
-Incidently, you can submit non-interactive jobs to SLURM using the `srun` command without the `--pty` parameter, for example:
+Incidently, you can submit non-interactive jobs to Slurm using the `srun` command without the `--pty` parameter, for example:
 
 ```bash
 	$ srun singularity exec /idia/software/containers/ASTRO-PY3.simg python myscript.py
@@ -171,7 +171,7 @@ This will run the Python script `myscript.py` using the ASTRO-PY3 container on a
 
 ### Persistent Terminals
 
-As with any ssh connection, when using an interactive shell via the `srun` or `sinteractive` command, your session is vulnerable to being killed if you lose network connectivity. To avoid this, you can use a persistent terminal tool such as GNU's `screen` or `tmux` for an interactive session that can be reaccessed after the loss of the ssh session. In order to use this feature, `tmux` should be run from the login node before running `srun`. However, when using `tmux`, please make sure to exit the `tmux` session once your interactive session is complete in order to release the resources back to the SLURM pool. Basic `tmux` commands include:
+As with any ssh connection, when using an interactive shell via the `srun` or `sinteractive` command, your session is vulnerable to being killed if you lose network connectivity. To avoid this, you can use a persistent terminal tool such as GNU's `screen` or `tmux` for an interactive session that can be reaccessed after the loss of the ssh session. In order to use this feature, `tmux` should be run from the login node before running `srun`. However, when using `tmux`, please make sure to exit the `tmux` session once your interactive session is complete in order to release the resources back to the Slurm pool. Basic `tmux` commands include:
 
 | Syntax/keyboard shortcut               | Action                                    |
 |----------------------------------------|-------------------------------------------|
@@ -182,23 +182,23 @@ As with any ssh connection, when using an interactive shell via the `srun` or `s
 | ctrl/cmd-b + [                         | scroll current terminal                   |
 
 An example work flow for an interactive session can be described as follows:
-* login in to slurm login node
+* login in to Slurm login node
 * run tmux (or screen)
 * use the srun or sinteractive command to allocate yourself a compute node, describing your required resources
 * open a Singularity container and run your software.
 
-Note: In the rare occasion that the SLURM login node is restarted, even persistent terminal sessions will be lost.
+Note: In the rare occasion that the Slurm login node is restarted, even persistent terminal sessions will be lost.
 
 
 ### Interactive Session with X11 Support
 
-In the event that you wish to use software that provides a GUI, such as `CASA plotms`, you can start an interactive session with `X11 forwarding`. You must `ssh` into the SLURM login node with the `-Y` parameter, which sets your DISPLAY variable for trusted `X11 forwarding`, for example:
+In the event that you wish to use software that provides a GUI, such as `CASA plotms`, you can start an interactive session with `X11 forwarding`. You must `ssh` into the Slurm login node with the `-Y` parameter, which sets your DISPLAY variable for trusted `X11 forwarding`, for example:
 
 ```bash
 	$ ssh -Y <username>@slurm.ilifu.ac.za
 ```
 
-From there, you must use `--x11` to allocate a SLURM worker node to yourself with `X11 forwarding` as follows:
+From there, you must use `--x11` to allocate a Slurm compute node to yourself with `X11 forwarding` as follows:
 
 ```bash
 	$ sinteractive --x11

--- a/docs/tech_docs/running_jobs.md
+++ b/docs/tech_docs/running_jobs.md
@@ -1,8 +1,8 @@
 # Submitting jobs to be run on the ilifu cluster
 
-There are several methods to run jobs on Ilifu.
+The Ilifu facility has two main services for accessing compute resources:
 
-1. Users may access a JupyterLab environment on the cluster. This provides a JupyterLab environment where users select what size compute node they need to run. This is a good environment for users to experiment with code and visualise certain results. This environment is available at [jupyter.ilifu.ac.za](https://jupyter.ilifu.ac.za)
+1. **Jupyter** Users may access a JupyterLab session on the cluster. The Ilifu Jupyter service allows users to select their desired compute resouces and dynamically spawn a Jupyter session. This is a good environment to experiment with code and visualise results. This jupyter service is available at [jupyter.ilifu.ac.za](https://jupyter.ilifu.ac.za)
 
 2. Users may access the Ilifu SLURM cluster login-node and submit tasks to the SLURM queue. This environment is available at [slurm.ilifu.ac.za](https://slurm.ilifu.ac.za).
 
@@ -10,12 +10,12 @@ There are several methods to run jobs on Ilifu.
 
 ## Jupyter Spawner
 
-The jupyter spawner can be accessed via web browser at `https://jupyter.ilifu.ac.za`.  This system allows the user to spawn a virtual machine on the Ilifu cloud running Jupyter Lab. Since the VM is launched for each user it allows for better management of resources, and provides a reliable environment for developing and running analyses, since users are not competing for resources on one or more shared nodes.
+The Jupyter spawner can be accessed via web browser at `https://jupyter.ilifu.ac.za`.  This system allows the user to spawn a virtual machine on the Ilifu cloud running Jupyter Lab. Since the VM is launched for each user it allows for better management of resources, and provides a reliable environment for developing and running analyses, since users are not competing for resources on one or more shared nodes.
 
-After logging into the jupyter node, one must select the type of node on which to run jupyter.  The user is presented with a drop-down list with various options, and should choose the smallest node that will provide sufficient resources for the task at hand:
+After logging into the Jupyter node, the user is presented with a drop-down menu with a list of options for compute resources. Please select the smallest node that will provide sufficient resources for the task at hand:
 ![dropdown](http://docs.ilifu.ac.za/_media/profile_dropdown_options.png)
 
-Each node will be terminated after a preset interval of time, however the user's jupyter environment is saved in their home directory, so when a new jupyter server is spawned the workspace is recreated. Some data is also persisted in the notebook file. A user can terminate the server in order to free up resources on the cloud, or to choose a different node type.  This is done by choosing `File > Hub Control Panel` option from the top menu bar of JupyterLab,
+Each node will be terminated after a preset interval of time, however the user's jupyter environment is saved in their home directory, so when a new jupyter server is spawned their workspace and notebooks will be recreated. Some data is also persisted in the notebook file, however any long-running processes will be terminated when the jupyter session is stopped, or when it reaches its time limit. The Jupyter service is designed for interactive development and analysis, not for high performance computing. For long running or resource heavy tasks, please refer to the Slurm Batch Scheduler section below). A user can terminate the Jupyter session in order to free up resources on the cloud, or to choose a different node type. This is done by choosing `File > Hub Control Panel` option from the top menu bar of JupyterLab,
 
 <img src="/_media/hub_selection.png" alt="menu bar options" width=500 />
 
@@ -52,13 +52,15 @@ The following table lists the available kernels and their related Singularity co
 
 Details of the python libraries, software and other libraries available within the different containers can be found in the [Available containers](tech_docs/software_environments?id=available-containers) section. An alternative way to view the available Python packages included in the kernel is to run the command `!pip freeze` in your Jupyter notebook. This command will list all the python packages available in the currently active kernel. To create a custom kernel for use in your Jupyter session, see [Using a custom container as a Jupyter kernel](tech_docs/software_environments?id=using-a-custom-container-as-a-jupyter-kernel).
 
+
+
 ## Slurm Batch Scheduler
 
-Slurm is a general purpose job scheduling system which is highly versatile.  There are numerous resources available online as to how to submit batch jobs and how to control the execution, concurrency, and dependencies of jobs.  This page provides instructions for connecting to the batch scheduler and a simple example to submit and run a SLURM batch job.
+Slurm is a general purpose job scheduling system which is highly versatile. There are numerous resources available online as to how to submit batch jobs and how to control the execution, concurrency, and dependencies of jobs. This page provides instructions for connecting to the batch scheduler and a simple example to submit and run a SLURM batch job.
 
-The SLURM batch system can be accessed via `ssh` with private key to `slurm.ilifu.ac.za`. Note that this node should only be used to submit and manage batch jobs and not for running code or software directly.  This node does not have significant resources and will likely crash under heavy usage.  From this node you can submit jobs to a queue where it subsequently allocated to the computing cluster such that it uses resources in an optimal manner.
+The SLURM batch system can be accessed via `ssh` with private key to `slurm.ilifu.ac.za`. Note that this node should only be used to submit and manage batch jobs and not for running code or software directly. The login node does not have significant resources and will likely crash under heavy usage. From this node you can submit jobs to a queue where it is subsequently allocated to the computing cluster such that it uses resources in an optimal manner.
 
-To do so, we must create a submit script.  In this example we will assume that the user is executing their analysis or data processing code using python.  We thus create a python script for each compute job called `casa_job_N.py`, where N represents the job number.  If you were working directly on your laptop you could run this script by running `python -c casa_job_N.py`.  However, since our script will be run on a worker node, we use a singularity container to encapsulate our environment and requisite software.  The simplest way to execute our python script is by prepending the `singularity exec` command:
+To do so, we must create a job submit script. In this example, we will assume that the user is executing their analysis or data processing code using python. We  also assume that your code is contained in a set of python script called `casa_job_N.py`, where N represents the job number. If you were working directly on your laptop, you could run this script by running `python -c casa_job_N.py`. However, since our script will be run on a worker node, we need to use a singularity container to encapsulate our system environment and requisite software. To execute our python script on the Ilifu cluster using a singularity container, we prepend `singularity exec` to this command:
 
 ```bash
 singularity exec /data/exp_soft/containers/casa-stable.img python -c casa_job_N.py
@@ -87,87 +89,122 @@ To submit this script to the job queue, run
 sbatch casaslurm_N.sh
 ```
 
-To check the progress of the jobs, use the `squeue` command or check the `logs` directory...
+To check the progress of the jobs, use the `squeue` command or check the `logs` directory.
+
+
 
 ## Interactive SLURM Sessions
 
-**No software should be run on the SLURM login node.** A shell terminal can be run on a compute node allowing for an interactive job on the cluster. Interactive jobs are useful for testing and developing code.
+An interactive session allows you to connect to a computing node and work on that node directly. There are several ways to use an interactive session on Ilifu. If you need to do work that you would normally do on a dedicated node, without waiting in the queue, the simplest option is to use the `sinteractive` command.  To use `sinteractive`, please see the Interactive Session Quick Start section below. 
 
-**NOTE:** interactive sessions are volatile and may be lost if you lose connection to the ilifu cluster. Persistent terminals, such as `tmux` or `screen` may help to reduce this volatility, however, in the event that the SLURM login node is restarted, the persistent terminal sessions will be lost. We therefore recommend that users submit jobs using `sbatch`, particularly for jobs with run times of greater than 3 hrs.
+For more sophisticated interactive usage, the `srun` command accomodates a variety of modes and options. See the Interactive Session Features section below for  common features of the `srun` command.
 
-**NOTE:** interactive sessions make use of the same resource pool as jobs submitted using `sbatch`. If you are experiencing delays acquiring an interactive session you can either try to reduce the number of resources (CPU, memory and run-time) that you are requesting, or use the parameter `--qos qos-interactive` when launching your interactive job. **This parameter provides increased priority but is limited to 1 job, 4 CPUs and 28 GB memory.**
+Please note the following before starting an interactive job:
 
-### Quick Interactive Session
+**Note:** Interactive sessions may be lost if you lose connection to the ilifu cluster. Persistent terminals, such as `tmux` or GNU `screen` can help to reduce volatility. See the section Persistent Terminals for instructions. 
 
-If you need to do interactive work and don't want to wait in the queue, the `sinteractive` command provides on-demand access to an allocation of resources in the `Devel` partition. It is designed to elimiate wait time by sharing resources between mulitple users. The `sinteractive` command can often be used in cases where a dedicated server would otherwise be used. That is, when testing scripts, developing code, compiling, or for other tasks that are difficult to accomplish with a batch queue system and which cannot be done on the login node.
+**Note:** In order is to ensure that resources are available in an optimal way for all users, interactive jobs are limited by time and compute resources. For work that uses significant compute resources, or that takes longer than three hours, we recommend that users submit jobs to the batch queue using `sbatch`. 
 
-The following command will launch a job in the `Devel` partition with four cores, X11 support, and will automatically open an virtual terminal on the appropriate node:
+**Note:** No software should be run on the SLURM login node (slurm.ilifu.ac.za). It should only be used to start, stop and monitor slurm jobs. 
+
+
+### Interactive Session Quick Start
+
+If you need to do interactive work and don't want to wait in the queue, the `sinteractive` command aims to provide on-demand access to resources on the `Devel` partition. This partition is designed to elimiate wait time by sharing resources between mulitple users. The `sinteractive` is a wrapper around the `srun` command that allows you to quickly start a job on the `Devel` partition, connect to the appropriate server, and work on that server directly with minimal configuration. 
+
+For example, run the following command on the login node to start an interactive session with four cores and X11 support:
 
 ```bash
 	$ sinteractive --x11 -c 4
 ```
 
-Most options that can be used with `sbatch` or `srun` can also be passed to the `sinteractive` command. We recommend specifying the flags for cpu (`-c` or `--cpus-per-core`) and for time (`--time=`), if you need more than the default time limit of three hours. The job will only remain active until the terminal is exited. Therefore, it is recommended to use `sinteractive` together with a tool such as `tmux` or `GNU screen` in order to maintain a persistent connection. See the instructions for `tmux` in the following section.
+After entering this command, you will be presented with a new prompt on a compute node where you can work directly.
 
-In order to provide immediate access for interactive tasks, resources are shared between all users on the `Devel` partition -- memory is not tracked and the cpus are oversubscribed. Please only request the number of cores that you need for the task at hand and be aware of your memory usage. 
+Most options that can be used with `sbatch` or `srun` can also be passed to the `sinteractive` command. We recommend specifying the flags for the number of cpus (`-c` or `--cpus-per-core`) and for job time (`--time=`). The default time limit for the Devel partition is three hours. The job will only remain active until the terminal is exited. Therefore, it is recommended to use `sinteractive` together with a persistent connection tool such as `tmux` or `GNU screen`. See the Persistent Terminals section below for instructions.
 
-For more features of interactive jobs, refer to the following sections. 
+In order to minimize wait time for interactive sessions, resources on the `Devel` partition are shared between all users -- memory is not tracked by slurm and the cpus are oversubscribed. Also, job time is limited to a maximum of twelve hours. Please only request the number of cores and time that you need for the task at hand and be aware of your memory usage. If you need an interactive job with additional features and options, with a dedicated allocation of compute resources, or that lasts longer than twelve hours, please use `srun` command, which is documented in the following section. 
 
-### Interactive Session without X11 Support
 
-For an interative session on the SLURM cluster the `srun` command can be used as follows, from the SLURM login node:
+### Interactive Session Features
+
+If you need an interative session with more time, resouces or options, the `srun` command can be used. From the SLURM login node, run the command:
 
 ```bash
 	$ srun --pty bash
 ```
 
-This will place you in an interactive shell (bash) session on a compute node. The `--pty` parameter provides a psuedo-terminal which allows interactivity. The default resources allocated by the `srun` command are 1 task, 1 CPU and 8 GB RAM. Run the `srun --help` command to see additional parameters. Similar parameters to the sbatch script above can be used to define the resources allocated to your interactive session. From the shell session, you are able to run interactive tasks, such as opening a Singularity container and loading an interactive CASA session, or utilizing Nextflow.
+This will place you in an interactive (bash) shell on a compute node in the Main partition. The `--pty` parameter provides a psuedo-terminal that allows for interactivity. The default resources allocated by the `srun` command are 1 task, 1 CPU and ~7 GB RAM. Run the `srun --help` command to see additional parameters. Similar parameters to the sbatch command can be used to define the resources and other options of your interactive session. From the shell session, you are able to run interactive tasks, such as opening a Singularity container to load an interactive CASA session, or to utilizing Nextflow.
 
-You are able to directly run Singularity containers or software within containers using the srun command, for example:
+To start an interactive session without waiting in the queue, the `Devel` partition can be used for an on-demand session on a resource-shared node.
+
+```bash
+	$ srun -p Devel --pty bash -i
+```
+
+Note that, as memory is not tracked in the `Devel` partition, specifying any memory argument (e.g. the -m or --mem flags) with the `Devel` partition will yeild an error stating that "Memory required by task is not available".
+
+You can directly run a Singularity containers or other software using the srun command, for example:
 
 ```bash
 	$ srun --pty singularity shell /idia/software/containers/ASTRO-PY3.simg
 ```
 
-This will open an interactive session on a compute node and open the ASTRO-PY3.simg container which includes a large suite of astronomy software. Alternatively, the following command will open an interactive CASA session on a compute node using the casa-stable.img container:
+This will start an interactive session on a compute node and open a shell in the `ASTRO-PY3` container, which contains a large suite of astronomy software. 
+
+Alternatively, the following command will open an interactive CASA session on a compute node using the casa-stable.img container:
 
 ```bash
 	$ srun --pty singularity exec /idia/software/containers/casa-stable.img casa --log2term --nologger
 ```
 
-Incidently, you can also submit non-interactive jobs to SLURM using the `srun` command without the `--pty` parameter, for example:
+Incidently, you can submit non-interactive jobs to SLURM using the `srun` command without the `--pty` parameter, for example:
 
 ```bash
 	$ srun singularity exec /idia/software/containers/ASTRO-PY3.simg python myscript.py
 ```
 
-This will run the Python script `myscript.py` using the `ASTRO-PY3` container on a compute node, similar to the `sbatch` command, however the job will not be run in the background, but will utilize your current terminal.
+This will run the Python script `myscript.py` using the ASTRO-PY3 container on a compute node, similar to the `sbatch` command, however the job will not be run in the background, but will utilize your current terminal.
 
-Note that when using an interactive shell on SLURM by using the `srun` command, your interactive session may be vulnerable to being killed if you lose network connectivity. To avoid this, you can use `tmux` for a persistent terminal that can be reaccessed after the loss of the ssh session. In order to use this feature, `tmux` should be run from the login node before running `srun`. However, when using `tmux`, please make sure to exit the `tmux` session once your interactive session is complete in order to release the resources back to the SLURM pool. Basic `tmux` commands include:
+**Note:** Interactive sessions using `srun` make use of the same resource pool as jobs submitted using `sbatch`. If you are experiencing delays acquiring an interactive session you can either try to reduce the number of resources (CPU, memory and run-time) that you are requesting, or use the parameter `--qos qos-interactive` when launching your interactive job. This parameter provides increased priority but is limited to 1 job, 4 CPUs and 28 GB memory. Alternatively, you can use the `Devel` partition (`srun -p Devel`) or the `sinteractive` command for on-demand access to a shared node.
+
+
+
+### Persistent Terminals
+
+As with any ssh connection, when using an interactive shell via the `srun` or `sinteractive` command, your session is vulnerable to being killed if you lose network connectivity. To avoid this, you can use a persistent terminal tool such as GNU's `screen` or `tmux` for an interactive session that can be reaccessed after the loss of the ssh session. In order to use this feature, `tmux` should be run from the login node before running `srun`. However, when using `tmux`, please make sure to exit the `tmux` session once your interactive session is complete in order to release the resources back to the SLURM pool. Basic `tmux` commands include:
 
 | Syntax/keyboard shortcut               | Action                                    |
 |----------------------------------------|-------------------------------------------|
 | tmux                                   | start new tmux session                    |
 | tmux ls                                | list currently active tmux sessions       |
-| tmux attach -t &#60;session_name&#62;| attach to an active tmux session          |
+| tmux attach -t &#60;session_name&#62;  | attach to an active tmux session          |
 | ctrl/cmd-b + d                         | detach from current tmux session          |
 | ctrl/cmd-b + [                         | scroll current terminal                   |
 
 An example work flow for an interactive session can be described as follows:
 * login in to slurm login node
 * run tmux (or screen)
-* use the srun command to allocate yourself a compute node, describing your required resources
+* use the srun or sinteractive command to allocate yourself a compute node, describing your required resources
 * open a Singularity container and run your software.
+
+Note: In the rare occasion that the SLURM login node is restarted, even persistent terminal sessions will be lost.
+
 
 ### Interactive Session with X11 Support
 
-In the event that you wish to use software which provides a GUI, such as `CASA plotms`, you can start an interactive session with `X11 forwarding`. You must `ssh` into the SLURM login node with the `-Y` parameter which sets your DISPLAY variable for trusted `X11 forwarding`, for example:
+In the event that you wish to use software that provides a GUI, such as `CASA plotms`, you can start an interactive session with `X11 forwarding`. You must `ssh` into the SLURM login node with the `-Y` parameter, which sets your DISPLAY variable for trusted `X11 forwarding`, for example:
 
 ```bash
 	$ ssh -Y <username>@slurm.ilifu.ac.za
 ```
 
 From there, you must use `--x11` to allocate a SLURM worker node to yourself with `X11 forwarding` as follows:
+
+```bash
+	$ sinteractive --x11
+```
+
+or,
 
 ```bash
 	$ srun --x11 --pty bash
@@ -180,6 +217,7 @@ This will place you in an interactive shell (bash) session on a compute node wit
 ```
 
 You are then able to run a Singularity container and run software that provides a GUI.
+
 
 <!--
 ### Interactive session with salloc


### PR DESCRIPTION
This is to rewrite the interactive slurm session documentation for readability and to clarify the difference between srun and sinteractive. Also some other revisions to the documents for clarity. 